### PR TITLE
Add Unity prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ocean-dive
-Core Gameplay Endless Runner Style: Similar to Temple Run, the game should be an endless runner with swipe-based controls.  Character: Replace the main character (Jack) with a mermaid. The mermaid swims forward through an underwater world.  Objective: Avoid underwater obstacles, collect pearls, and escape from a chasing sea predator.
+
+This repository contains prototypes for the **Mermaid Runner** endless runner game.
+
+- `unity/` – C# scripts for a Unity implementation.
+- `mermaid_runner.py` – A legacy Pygame prototype.
+- `gamemaker/` – GML scripts for a GameMaker implementation.
+
+Use the GameMaker scripts to create objects (`obj_player`, `obj_obstacle`, `obj_controller`, `obj_chaser`) and attach the code to their events as explained in `gamemaker/README.md`. The GameMaker implementation also makes use of free Marketplace assets: **Draw Sprite Along Path**, **Dijkstra Path Finding**, and **Dusty Chip I Music Library**.
+
+For a Unity version of the game, copy the contents of the `unity/Assets` folder into a new Unity 2D project. The included scripts handle player movement, obstacle spawning, and the ocean current mechanic.
+
+The latest prototype features an **ocean current** acting as the runner's path. Once the mermaid is pulled into the current she cannot escape without taking damage.

--- a/gamemaker/README.md
+++ b/gamemaker/README.md
@@ -1,0 +1,33 @@
+# Mermaid Runner - GameMaker Implementation
+
+This folder contains simple GameMaker Language (GML) scripts to build the Mermaid Runner prototype. Import these scripts into a GameMaker project and assign them to objects/events as noted.
+
+The mermaid swims along a powerful ocean current. Once she is inside this current, attempts to leave will injure her.
+
+## Scripts
+
+- `player_create.gml` – Create Event for `obj_player`
+- `player_step.gml` – Step Event for `obj_player`
+- `obstacle_create.gml` – Create Event for `obj_obstacle`
+- `obstacle_step.gml` – Step Event for `obj_obstacle`
+- `controller_create.gml` – Create Event for `obj_controller`
+- `controller_step.gml` – Step Event for `obj_controller` (handles obstacle spawning)
+- `chaser_step.gml` – Step Event for `obj_chaser` (follows the player)
+
+## Usage
+
+1. Create the objects `obj_player`, `obj_obstacle`, `obj_controller`, and `obj_chaser` in GameMaker.
+2. Attach the relevant scripts to their respective events.
+3. Place `obj_controller` in the starting room to manage obstacle spawning and game state.
+4. Run the game to test the endless runner mechanics.
+
+## Marketplace Assets
+
+Import the following free assets from the GameMaker Marketplace:
+
+1. **Draw Sprite Along Path** – <https://marketplace.gamemaker.io/assets/1602/draw-sprite-along-path>
+   - Use this to smoothly animate sprites following predefined paths. Apply it in the mermaid's Draw event or when spawning obstacles that travel along curves.
+2. **Dijkstra Path Finding** – <https://marketplace.gamemaker.io/assets/5726/dijkstra-path-finding>
+   - Provides scripts for grid-based navigation. Use these scripts in `chaser_step.gml` so the octopus can navigate around obstacles while pursuing the player.
+3. **Dusty Chip I Music Library** – <https://marketplace.gamemaker.io/assets/438/dusty-chip-i-music-library>
+   - Import these chiptune tracks and play one in `controller_create.gml` using `audio_play_sound()` for background music.

--- a/gamemaker/chaser_step.gml
+++ b/gamemaker/chaser_step.gml
@@ -1,0 +1,12 @@
+// obj_chaser Step Event
+// Follow the player's x and y position with slight lag
+var target = obj_player;
+if (instance_exists(target)) {
+    x = lerp(x, target.x - 200, 0.05);
+    y = lerp(y, target.y, 0.05);
+}
+
+// Optional: replace the simple lerp with the Dijkstra Path Finding asset.
+// Example usage after importing the asset:
+// var chase_path = scr_dijkstra_path(global.nav_grid, x, y, target.x, target.y);
+// path_start(chase_path, 4, path_action_stop, false);

--- a/gamemaker/controller_create.gml
+++ b/gamemaker/controller_create.gml
@@ -1,0 +1,10 @@
+// obj_controller Create Event
+spawn_delay = 60; // frames
+spawn_timer = 0;
+
+// After importing the Dusty Chip I Music Library asset, play a track
+// as background music. Replace `snd_dusty_title` with the actual
+// sound resource name from the asset.
+if (!audio_is_playing(snd_dusty_title)) {
+    audio_play_sound(snd_dusty_title, 1, true);
+}

--- a/gamemaker/controller_step.gml
+++ b/gamemaker/controller_step.gml
@@ -1,0 +1,6 @@
+// obj_controller Step Event
+spawn_timer += 1;
+if (spawn_timer > spawn_delay) {
+    instance_create_layer(room_width + 32, irandom_range(50, room_height - 50), "Instances", obj_obstacle);
+    spawn_timer = 0;
+}

--- a/gamemaker/obstacle_create.gml
+++ b/gamemaker/obstacle_create.gml
@@ -1,0 +1,3 @@
+// obj_obstacle Create Event
+x = room_width + sprite_width;
+y = irandom_range(50, room_height - 50);

--- a/gamemaker/obstacle_step.gml
+++ b/gamemaker/obstacle_step.gml
@@ -1,0 +1,5 @@
+// obj_obstacle Step Event
+x -= 5;
+if (x < -sprite_width) {
+    instance_destroy();
+}

--- a/gamemaker/player_create.gml
+++ b/gamemaker/player_create.gml
@@ -1,0 +1,4 @@
+// obj_player Create Event
+x = 100;
+y = room_height / 2;
+vertical_speed = 0;

--- a/gamemaker/player_step.gml
+++ b/gamemaker/player_step.gml
@@ -1,0 +1,15 @@
+// obj_player Step Event
+if (keyboard_check(vk_up)) {
+    vertical_speed = -5;
+} else if (keyboard_check(vk_down)) {
+    vertical_speed = 5;
+} else {
+    vertical_speed = 0;
+}
+
+y += vertical_speed;
+y = clamp(y, 0, room_height - sprite_height);
+
+// After importing the Draw Sprite Along Path asset, you can animate the
+// mermaid along a curved path in the Draw event using the provided
+// `draw_sprite_along_path()` script.

--- a/mermaid_runner.py
+++ b/mermaid_runner.py
@@ -1,0 +1,131 @@
+import pygame
+import random
+
+# Game settings
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+FPS = 60
+
+# Player constants
+PLAYER_SPEED = 5
+ASCEND_SPEED = -10
+DIVE_SPEED = 10
+
+# Obstacle settings
+OBSTACLE_SPEED = 5
+OBSTACLE_FREQ = 1500  # milliseconds
+
+# Ocean current settings
+CURRENT_RECT = pygame.Rect(0, SCREEN_HEIGHT // 2 + 50, SCREEN_WIDTH, 100)
+MAX_HEALTH = 3
+
+class Player(pygame.sprite.Sprite):
+    def __init__(self):
+        super().__init__()
+        self.image = pygame.Surface((50, 30))
+        self.image.fill((0, 255, 255))  # Placeholder color for mermaid
+        self.rect = self.image.get_rect()
+        self.rect.center = (100, SCREEN_HEIGHT // 2)
+        self.velocity_y = 0
+        self.in_current = False
+
+    def update(self, current_rect, game):
+        keys = pygame.key.get_pressed()
+        if keys[pygame.K_UP]:
+            self.velocity_y = ASCEND_SPEED
+        elif keys[pygame.K_DOWN]:
+            self.velocity_y = DIVE_SPEED
+        else:
+            self.velocity_y = 0
+
+        self.rect.y += self.velocity_y
+        self.rect.y = max(0, min(SCREEN_HEIGHT - self.rect.height, self.rect.y))
+
+        if not self.in_current and self.rect.colliderect(current_rect):
+            self.in_current = True
+            print('The ocean current pulled you in!')
+
+        if self.in_current:
+            if not self.rect.colliderect(current_rect):
+                self.rect.clamp_ip(current_rect)
+                game.hurt()
+
+class Obstacle(pygame.sprite.Sprite):
+    def __init__(self, x):
+        super().__init__()
+        self.image = pygame.Surface((40, 40))
+        self.image.fill((255, 0, 0))
+        self.rect = self.image.get_rect()
+        self.rect.x = x
+        self.rect.y = random.randint(50, SCREEN_HEIGHT - 50)
+
+    def update(self):
+        self.rect.x -= OBSTACLE_SPEED
+        if self.rect.right < 0:
+            self.kill()
+
+class Game:
+    def __init__(self):
+        pygame.init()
+        pygame.mixer.init()
+        self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+        pygame.display.set_caption('Mermaid Runner')
+        self.clock = pygame.time.Clock()
+        self.running = True
+        self.health = MAX_HEALTH
+        self.current_rect = CURRENT_RECT
+        self.font = pygame.font.SysFont(None, 36)
+
+        # Load music from the Dusty Chip I Music Library (placeholder path)
+        # Place one of the asset's OGG files in the project directory
+        # and replace 'dusty_title.ogg' with the actual filename.
+        try:
+            pygame.mixer.music.load('dusty_title.ogg')
+            pygame.mixer.music.play(-1)
+        except pygame.error:
+            print('Background music file not found.')
+
+        self.player = Player()
+        self.all_sprites = pygame.sprite.Group(self.player)
+        self.obstacles = pygame.sprite.Group()
+
+        pygame.time.set_timer(pygame.USEREVENT + 1, OBSTACLE_FREQ)
+
+    def hurt(self):
+        self.health -= 1
+        print(f'Hurt by the current! Health: {self.health}')
+        if self.health <= 0:
+            print('Game Over!')
+            self.running = False
+
+    def run(self):
+        while self.running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.running = False
+                if event.type == pygame.USEREVENT + 1:
+                    self.spawn_obstacle()
+
+            self.player.update(self.current_rect, self)
+            self.obstacles.update()
+
+            if pygame.sprite.spritecollideany(self.player, self.obstacles):
+                print('Game Over!')
+                self.running = False
+
+            self.screen.fill((0, 0, 128))
+            pygame.draw.rect(self.screen, (0, 64, 200), self.current_rect)
+            self.all_sprites.draw(self.screen)
+            self.obstacles.draw(self.screen)
+            health_surf = self.font.render(f'Health: {self.health}', True, (255, 255, 255))
+            self.screen.blit(health_surf, (10, 10))
+            pygame.display.flip()
+            self.clock.tick(FPS)
+
+    def spawn_obstacle(self):
+        obstacle = Obstacle(SCREEN_WIDTH + 20)
+        self.obstacles.add(obstacle)
+        self.all_sprites.add(obstacle)
+
+if __name__ == '__main__':
+    Game().run()

--- a/unity/Assets/Scripts/Chaser.cs
+++ b/unity/Assets/Scripts/Chaser.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+public class Chaser : MonoBehaviour
+{
+    public Transform target;
+    public float followSpeed = 4f;
+
+    void Update()
+    {
+        if (target != null)
+        {
+            Vector3 pos = transform.position;
+            pos = Vector3.Lerp(pos, target.position, followSpeed * Time.deltaTime);
+            transform.position = pos;
+        }
+    }
+}

--- a/unity/Assets/Scripts/GameManager.cs
+++ b/unity/Assets/Scripts/GameManager.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class GameManager : MonoBehaviour
+{
+    public GameObject obstaclePrefab;
+    public float spawnInterval = 2f;
+    public float obstacleSpeed = 5f;
+    public int maxHealth = 3;
+
+    private float timer = 0f;
+    private int health;
+    private readonly List<GameObject> obstacles = new();
+    private AudioSource audioSource;
+
+    void Start()
+    {
+        health = maxHealth;
+        audioSource = GetComponent<AudioSource>();
+        if (audioSource != null)
+        {
+            audioSource.loop = true;
+            audioSource.Play();
+        }
+    }
+
+    void Update()
+    {
+        timer += Time.deltaTime;
+        if (timer >= spawnInterval)
+        {
+            SpawnObstacle();
+            timer = 0f;
+        }
+
+        for (int i = obstacles.Count - 1; i >= 0; i--)
+        {
+            obstacles[i].transform.Translate(Vector3.left * obstacleSpeed * Time.deltaTime);
+            if (obstacles[i].transform.position.x < -10f)
+            {
+                Destroy(obstacles[i]);
+                obstacles.RemoveAt(i);
+            }
+        }
+    }
+
+    void SpawnObstacle()
+    {
+        Vector3 pos = new Vector3(10f, Random.Range(-3f, 3f), 0f);
+        obstacles.Add(Instantiate(obstaclePrefab, pos, Quaternion.identity));
+    }
+
+    public void Hurt()
+    {
+        health -= 1;
+        Debug.Log("Hurt! Health: " + health);
+        if (health <= 0)
+        {
+            Debug.Log("Game Over!");
+        }
+    }
+}

--- a/unity/Assets/Scripts/Obstacle.cs
+++ b/unity/Assets/Scripts/Obstacle.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class Obstacle : MonoBehaviour
+{
+    void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            GameManager gm = FindObjectOfType<GameManager>();
+            if (gm != null)
+            {
+                gm.Hurt();
+            }
+        }
+    }
+}

--- a/unity/Assets/Scripts/OceanCurrent.cs
+++ b/unity/Assets/Scripts/OceanCurrent.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class OceanCurrent : MonoBehaviour
+{
+    void OnTriggerExit2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            GameManager gm = FindObjectOfType<GameManager>();
+            if (gm != null)
+            {
+                gm.Hurt();
+            }
+
+            // Keep the player inside the current bounds
+            var bounds = GetComponent<Collider2D>().bounds;
+            Vector3 pos = other.transform.position;
+            pos.y = Mathf.Clamp(pos.y, bounds.min.y, bounds.max.y);
+            other.transform.position = pos;
+        }
+    }
+}

--- a/unity/Assets/Scripts/PlayerController.cs
+++ b/unity/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    public float forwardSpeed = 5f;
+    public float verticalSpeed = 5f;
+    private Rigidbody2D rb;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody2D>();
+    }
+
+    void Update()
+    {
+        float v = Input.GetAxisRaw("Vertical");
+        Vector2 vel = rb.velocity;
+        vel.x = forwardSpeed;
+        vel.y = v * verticalSpeed;
+        rb.velocity = vel;
+    }
+}

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,0 +1,31 @@
+# Mermaid Runner - Unity Prototype
+
+This folder contains basic C# scripts to build the Mermaid Runner game in Unity.
+Create a new **2D** project and copy the `Assets` directory into it.
+
+The scripts implement a side-scrolling endless runner set underwater with an
+ocean current that keeps the mermaid on a fixed path. Leaving the current hurts
+the player.
+
+## Scripts
+
+- `PlayerController.cs` – moves the mermaid forward and allows vertical control.
+- `OceanCurrent.cs` – clamps the player inside the current and applies damage
+  when she attempts to exit.
+- `GameManager.cs` – spawns obstacles, tracks health, and plays background music
+  (add an `AudioSource` component with a track from the **Dusty Chip I Music
+  Library**).
+- `Obstacle.cs` – deals damage when the player collides with an obstacle.
+- `Chaser.cs` – simple follower script for the octopus pursuing the player.
+
+Attach these scripts to your prefabs:
+
+1. **Player** GameObject with a `Rigidbody2D` and `Collider2D` tagged `Player`.
+2. **OceanCurrent** area using a `BoxCollider2D` set as Trigger and the
+   `OceanCurrent` script.
+3. **GameManager** empty object with the `GameManager` script and an
+   `AudioSource` component (add a music file from the Dusty Chip I pack).
+4. **Obstacle** prefab with a `Collider2D` set as Trigger using `Obstacle`.
+5. **Chaser** object with the `Chaser` script, assigning the Player as target.
+
+Press **Play** to test the endless running and obstacle spawning.


### PR DESCRIPTION
## Summary
- add Unity version under `unity/` with C# scripts
- update README to mention Unity prototype alongside legacy Pygame code
- document how to set up the Unity project and ocean current mechanic

## Testing
- `python3 mermaid_runner.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_b_685510e944b4832db7d59899971b0a6e